### PR TITLE
Conditional Check On featured Content

### DIFF
--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -19,7 +19,9 @@ function jetpack_load_theme_tools() {
 add_action( 'init', 'jetpack_load_theme_tools', 30 );
 
 // Featured Content has an internal check for theme support in the constructor.
-require_once( JETPACK__PLUGIN_DIR . 'modules/theme-tools/featured-content.php' );
+if ( ! class_exists( 'Featured_Content' ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
+    require_once( JETPACK__PLUGIN_DIR . 'modules/theme-tools/featured-content.php' );
+}
 
 /**
  * INFINITE SCROLL


### PR DESCRIPTION
Wrapped call to featured-content.php in an if !class-exist wrap to avoid
conflict with Fourteen Extended plugin.

Although you are planning to deprecate the plugin current users are facing a conflict issue which this pull request fixes - issued for your review and inclusion.
