### PR TITLE
Setting this.snowColor = '#eee';

### DIFF
--- a/modules/holiday-snow/snowstorm.js
+++ b/modules/holiday-snow/snowstorm.js
@@ -21,7 +21,7 @@ var snowStorm = (function(window, document) {
   this.excludeMobile = true;      // Snow is likely to be bad news for mobile phones' CPUs (and batteries.) By default, be nice.
   this.flakeBottom = null;        // Integer for Y axis snow limit, 0 or null for "full-screen" snow effect
   this.followMouse = true;        // Snow movement can respond to the user's mouse
-  this.snowColor = '#fff';        // Don't eat (or use?) yellow snow.
+  this.snowColor = '#eee';        // Don't eat (or use?) yellow snow.
   this.snowCharacter = '&bull;';  // &bull; = bullet, &middot; is square on some systems etc.
   this.snowStick = false;          // Whether or not snow should "stick" at the bottom. When off, will never collect.
   this.targetElement = null;      // element which snow will be appended to (null = document.body) - can be an element ID eg. 'myDiv', or a DOM node reference


### PR DESCRIPTION
A majority of themes uses a white background, on which you won't be able to see white snowflakes.
Setting the color of snow flakes to #eee makes them viewable on white background while they still appear to be white (and not yellow :) ).
